### PR TITLE
fix: Fix ingress of deprecated message annotations

### DIFF
--- a/templates/ingress-class.yaml
+++ b/templates/ingress-class.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: traefik
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: traefik.io/ingress-controller


### PR DESCRIPTION
## What problem is this solving?
    When you apply an ingress manifest with the annotation "kubernetes.io/ingress.class:Bringfik" that displays a message with an error, this indicates that the annotation is deprecated in new versions of the Kuberntes cluster.

## Types of changes

- [X] Add ingress-class.yaml

## You can see the information in these link. 

- (https://cloud.google.com/kubernetes-engine/docs/how-to/custom-ingress-controller?hl=es-419)
- https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class

## Checklist


- [X] New feature (a non-breaking change which adds functionality)
- [X] Requires change to documentation, which has been updated accordingly.


## Screenshots


